### PR TITLE
Fixed issue with template parts not showing the right parts

### DIFF
--- a/what-the-file.php
+++ b/what-the-file.php
@@ -126,8 +126,18 @@ class WhatTheFile
 			return;
 		}
 
-		if( $slug != null && $name != null ){
-			$this->template_parts[] = $slug . '-' . $name . '.php';
+		if( $slug != null ){
+			$templates = array();
+
+			if($name != null)
+				$templates[] = "{$slug}-{$name}.php";
+
+			$templates[] = "{$slug}.php";
+
+			$found = locate_template($templates);
+			$found = str_replace(get_template_directory().'/', '', $found);
+			if($found != '')
+				$this->template_parts[] = $found;
 		}
 	}
 


### PR DESCRIPTION
If the "{$slug}-{$name}.php" doesn't exist what-the-file shows it as a template part, this is now fixed.
