### PR TITLE
Fixed wrong aligned arrow in MP6

### DIFF
--- a/what-the-file.php
+++ b/what-the-file.php
@@ -133,7 +133,7 @@ class WhatTheFile
 
 			// Get the correct template part
 			$template_part = str_replace( get_template_directory().'/', '', locate_template( $templates ) );
-			$template_part = str_replace( get_stylesheet_directory().'/', '', locate_template( $templates ) );
+			$template_part = str_replace( get_stylesheet_directory().'/', '', $template_part );
 
 			// Add template part if found
 			if( $template_part != '' )
@@ -183,7 +183,7 @@ class WhatTheFile
 
 		if( $this->template_name == '' ) {
 			$this->template_name = str_ireplace( get_template_directory() . '/', '', $template );
-			$this->template_name = str_ireplace( get_stylesheet_directory() . '/', '', $template );
+			$this->template_name = str_ireplace( get_stylesheet_directory() . '/', '', $this->template_name );
 		}
 
 	}


### PR DESCRIPTION
Fix the arrow for the template parts menu being aligned on the right side instead of the left side, where it should be.
